### PR TITLE
Merge Xcode results with plugin results.

### DIFF
--- a/KSImageNamed/IDEIndexCompletionStrategy+KSImageNamed.m
+++ b/KSImageNamed/IDEIndexCompletionStrategy+KSImageNamed.m
@@ -123,8 +123,9 @@
                                                inSortedRange:destinationRange
                                                      options:NSBinarySearchingInsertionIndex|NSBinarySearchingLastEqual
                                              usingComparator:^NSComparisonResult(IDEIndexCompletionItem *left, IDEIndexCompletionItem *right) {
-                                                 return [left.name compare:right.name];
+                                                 return [left.name caseInsensitiveCompare:right.name];
                                              }];
+
         [destination insertObject:obj atIndex:insertionIdx];
         destinationRange.location = insertionIdx;
         destinationRange.length = [destination count] - insertionIdx;


### PR DESCRIPTION
This way, local variables and constants are still autocompleted.

Caveat: since the plugin shows the autocomplete list as soon as
imageNamed is found, and I haven't found a way to:
- show only part of the results when no partial text have been writen.
- show the plugin results with more priority as default.
At this moment the full list of autocompletion options get shown,
probably showing the last autocompleted result as default.

If you know a way to do some of the above (it seems to me that `completionItemsForDocumentLocation:context:areDefinitive:` is only called once) it will be nice: when the user haven't typed anything only the plugin results get shown, if the user types something, the rest of the result are added.

This should take care of #3