### PR TITLE
Added gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,17 @@
+# Xcode
+.DS_Store
+*/build/*
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+xcuserdata
+profile
+*.moved-aside
+DerivedData
+.idea/
+*.hmap


### PR DESCRIPTION
Added a .gitignore file so that after building the project to install it the repository doesn't show as being dirty. This allows developers to more easily see when there are updates to the Xcode plugin using repository monitoring tools. Also avoids having to manually remember not to check in derived user data when submitting pull requests.

I added the github default gitignore from https://github.com/github/gitignore/blob/master/Objective-C.gitignore
