### PR TITLE
Eliminate unnecessary CPU usage

### DIFF
--- a/KSImageNamed.xcodeproj/project.pbxproj
+++ b/KSImageNamed.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		37E5303315FE7E6300753EB4 /* KSImageNamed.m in Sources */ = {isa = PBXBuildFile; fileRef = 37E5303215FE7E6300753EB4 /* KSImageNamed.m */; };
 		37E5303515FE7F4200753EB4 /* AppKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 37E5303415FE7F4200753EB4 /* AppKit.framework */; };
 		37E5303715FE7F4600753EB4 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 37E5303615FE7F4600753EB4 /* Foundation.framework */; };
+		586F70C51818C1C900A91B84 /* DVTTextCompletionListWindowController+KSImageNamed.m in Sources */ = {isa = PBXBuildFile; fileRef = 586F70C41818C1C900A91B84 /* DVTTextCompletionListWindowController+KSImageNamed.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -59,6 +60,8 @@
 		37E5303215FE7E6300753EB4 /* KSImageNamed.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KSImageNamed.m; sourceTree = "<group>"; };
 		37E5303415FE7F4200753EB4 /* AppKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppKit.framework; path = System/Library/Frameworks/AppKit.framework; sourceTree = SDKROOT; };
 		37E5303615FE7F4600753EB4 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
+		586F70C31818C1C900A91B84 /* DVTTextCompletionListWindowController+KSImageNamed.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "DVTTextCompletionListWindowController+KSImageNamed.h"; sourceTree = "<group>"; };
+		586F70C41818C1C900A91B84 /* DVTTextCompletionListWindowController+KSImageNamed.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "DVTTextCompletionListWindowController+KSImageNamed.m"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -129,6 +132,8 @@
 				3727E3B416AB350F007DACD3 /* DVTSourceTextView+KSImageNamed.m */,
 				37B5873416AF5BD500B4787D /* DVTTextCompletionController+KSImageNamed.h */,
 				37B5873516AF5BD500B4787D /* DVTTextCompletionController+KSImageNamed.m */,
+				586F70C31818C1C900A91B84 /* DVTTextCompletionListWindowController+KSImageNamed.h */,
+				586F70C41818C1C900A91B84 /* DVTTextCompletionListWindowController+KSImageNamed.m */,
 				37A2B52B15FE927F00D9AE1E /* MethodSwizzle.h */,
 				37A2B52C15FE927F00D9AE1E /* MethodSwizzle.m */,
 				3727E3AE16AB341A007DACD3 /* XcodeMisc.h */,
@@ -213,6 +218,7 @@
 				37E5303315FE7E6300753EB4 /* KSImageNamed.m in Sources */,
 				37A2B52D15FE927F00D9AE1E /* MethodSwizzle.m in Sources */,
 				37CEBA7815FE96F40090E015 /* KSImageNamedIndexCompletionItem.m in Sources */,
+				586F70C51818C1C900A91B84 /* DVTTextCompletionListWindowController+KSImageNamed.m in Sources */,
 				3727E3B216AB34AA007DACD3 /* IDEIndexCompletionStrategy+KSImageNamed.m in Sources */,
 				3727E3B516AB350F007DACD3 /* DVTSourceTextView+KSImageNamed.m in Sources */,
 				37B5873616AF5BD500B4787D /* DVTTextCompletionController+KSImageNamed.m in Sources */,

--- a/KSImageNamed/DVTTextCompletionController+KSImageNamed.m
+++ b/KSImageNamed/DVTTextCompletionController+KSImageNamed.m
@@ -17,10 +17,6 @@
 + (void)load
 {
     MethodSwizzle(self, @selector(acceptCurrentCompletion), @selector(swizzle_acceptCurrentCompletion));
-    
-    MethodSwizzle(self,
-                  @selector(textViewShouldChangeTextInRange:replacementString:),
-                  @selector(swizzle_textViewShouldChangeTextInRange:replacementString:));
 }
 
 - (BOOL)swizzle_acceptCurrentCompletion
@@ -50,71 +46,4 @@
     
     return success;
 }
-
-- (BOOL)swizzle_textViewShouldChangeTextInRange:(NSRange)arg1 replacementString:(NSString *)replacementString
-{
-    BOOL result = [self swizzle_textViewShouldChangeTextInRange:arg1 replacementString:replacementString];
-    
-    @try {
-        if (replacementString) {
-            id document = [[[self.textView window] windowController] document];
-            id index = [[document performSelector:@selector(workspace)] performSelector:@selector(index)];
-            
-            NSArray *imageCompletions = [[KSImageNamed sharedPlugin] imageCompletionsForIndex:index];
-            
-            NSInteger indexOfString = [imageCompletions indexOfObjectPassingTest:^BOOL(KSImageNamedIndexCompletionItem *item, NSUInteger idx, BOOL *stop) {
-                if ([item.fileName isEqualToString:replacementString]) {
-                    *stop = YES;
-                    return YES;
-                }
-                else {
-                    return NO;
-                }
-            }];
-            
-            NSImage *image = nil;
-            if (indexOfString != NSNotFound) {
-                KSImageNamedIndexCompletionItem *completionItem = imageCompletions[indexOfString];
-                image = [[[NSImage alloc] initWithContentsOfURL:completionItem.imageFileURL] autorelease];
-            }
-            
-            [self showPreviewForImage:image];
-        }
-    }
-    @catch (NSException *exception) {
-        //I'd rather not crash if Xcode chokes on something
-    }
-    
-    return result;
-}
-
-- (void)showPreviewForImage:(NSImage *)image
-{
-    KSImageNamedPreviewWindow *imageWindow = [KSImageNamed sharedPlugin].imageWindow;
-    
-    imageWindow.image = image;
-    
-    if (!image) {
-        [imageWindow orderOut:self];
-    } else {
-        NSRect imgRect = NSMakeRect(0.0, 0.0, image.size.width, image.size.height);
-        
-        NSImageView *imageView = [[[NSImageView alloc] initWithFrame:imgRect] autorelease];
-        imageView.image = image;
-        
-        id currentDVTTextCompletionSession = [self currentSession];
-        id currentDVTTextCompletionListWindowController = [currentDVTTextCompletionSession _listWindowController];
-        NSWindow *completionListWindow = [currentDVTTextCompletionListWindowController window];
-        
-        if ([completionListWindow isVisible] && [[currentDVTTextCompletionListWindowController _selectedCompletionItem] isKindOfClass:[KSImageNamedIndexCompletionItem class]]) {
-            NSRect completionListWindowFrame = completionListWindow ? completionListWindow.frame : NSMakeRect(image.size.width, image.size.height, 0.0, 0.0);
-            
-            [imageWindow setFrameTopRightPoint:NSMakePoint(completionListWindowFrame.origin.x - 1.0,
-                                                          completionListWindowFrame.origin.y + completionListWindowFrame.size.height)];
-            
-            [[NSApp keyWindow] addChildWindow:imageWindow ordered:NSWindowAbove];
-        }
-    }
-}
-
 @end

--- a/KSImageNamed/DVTTextCompletionListWindowController+KSImageNamed.h
+++ b/KSImageNamed/DVTTextCompletionListWindowController+KSImageNamed.h
@@ -1,0 +1,13 @@
+//
+//  DVTTextCompletionListWindowController+KSImageNamed.h
+//  KSImageNamed
+//
+//  Created by Jack Chen on 24/10/2013.
+//
+//
+
+#import "XcodeMisc.h"
+
+@interface DVTTextCompletionListWindowController (KSImageNamed)
+
+@end

--- a/KSImageNamed/DVTTextCompletionListWindowController+KSImageNamed.m
+++ b/KSImageNamed/DVTTextCompletionListWindowController+KSImageNamed.m
@@ -1,0 +1,65 @@
+//
+//  DVTTextCompletionListWindowController+KSImageNamed.m
+//  KSImageNamed
+//
+//  Created by Jack Chen on 24/10/2013.
+//
+//
+
+#import "DVTTextCompletionListWindowController+KSImageNamed.h"
+#import "MethodSwizzle.h"
+#import "KSImageNamedIndexCompletionItem.h"
+#import "KSImageNamed.h"
+#import "KSImageNamedPreviewWindow.h"
+
+@implementation DVTTextCompletionListWindowController (KSImageNamed)
+
++ (void)load
+{
+    MethodSwizzle(self, @selector(showInfoPaneForCompletionItem:), @selector(swizzle_showInfoPaneForCompletionItem:));
+    MethodSwizzle(self, @selector(_hideWindow), @selector(swizzle__hideWindow));
+}
+
+- (void)swizzle_showInfoPaneForCompletionItem:(id)item
+{
+    [self swizzle_showInfoPaneForCompletionItem:item];
+    
+    if ([item isKindOfClass:[KSImageNamedIndexCompletionItem class]]) {
+        NSImage *image = [[[NSImage alloc] initWithContentsOfURL:((KSImageNamedIndexCompletionItem *)item).imageFileURL] autorelease];
+        [self showPreviewForImage:image];
+    }
+}
+
+- (void)swizzle__hideWindow
+{
+    [[KSImageNamed sharedPlugin].imageWindow orderOut:self];
+    [self swizzle__hideWindow];
+}
+
+- (void)showPreviewForImage:(NSImage *)image
+{
+    KSImageNamedPreviewWindow *imageWindow = [KSImageNamed sharedPlugin].imageWindow;
+    
+    imageWindow.image = image;
+    
+    if (!image) {
+        [imageWindow orderOut:self];
+    } else {
+        NSRect imgRect = NSMakeRect(0.0, 0.0, image.size.width, image.size.height);
+        
+        NSImageView *imageView = [[[NSImageView alloc] initWithFrame:imgRect] autorelease];
+        imageView.image = image;
+        
+        NSWindow *completionListWindow = [self window];
+        
+        if ([completionListWindow isVisible]) {
+            NSRect completionListWindowFrame = completionListWindow ? completionListWindow.frame : NSMakeRect(image.size.width, image.size.height, 0.0, 0.0);
+            
+            [imageWindow setFrameTopRightPoint:NSMakePoint(completionListWindowFrame.origin.x - 1.0,
+                                                           completionListWindowFrame.origin.y + completionListWindowFrame.size.height)];
+            
+            [[NSApp keyWindow] addChildWindow:imageWindow ordered:NSWindowAbove];
+        }
+    }
+}
+@end

--- a/KSImageNamed/XcodeMisc.h
+++ b/KSImageNamed/XcodeMisc.h
@@ -101,6 +101,8 @@
 
 @interface DVTTextCompletionListWindowController : NSWindowController
 - (id)_selectedCompletionItem;
+- (void)showInfoPaneForCompletionItem:(id)arg1;
+- (void)_hideWindow;
 @end
 
 @interface IDEIndexCompletionStrategy : NSObject


### PR DESCRIPTION
`KSImageNamed` normally hooks into `textViewShouldChangeTextInRange:replacementString:`, which causes a lot of `KSImageNamed` methods to be hit _every time_ the text view changes.

Here is a paste of Obj-C message sends matching _KSImageNamed_ when I press `Return` only once on an empty line: https://gist.github.com/chendo/7130668

After poking around in `DVTTextCompletionController+KSImageNamed` and looking at the trace, it seems that `replacementString` is never nil (at least in Xcode 5.0.1), which is causing `imageCompletions` to be enumerated _every single time_ text changes.

This would be particularly bad in a project with many image assets.

This PR removes the textView swizzle and hooks into `DVTTextCompletionListWindow`'s `showInfoPaneForCompletionItem:` and `_hideWindow` methods, so `KSImageNamed` is only run when necessary.

Below is the remaining Obj-C message sends matching _KSImageNamed_ when pressing `Return` once on an empty line after applying this PR:

```
-> -[DVTTextCompletionController(KSImageNamed) swizzle_acceptCurrentCompletion]
<- -[DVTTextCompletionController(KSImageNamed) swizzle_acceptCurrentCompletion]
-> -[DVTSourceTextView(KSImageNamedSwizzle) swizzle_shouldAutoCompleteAtLocation:]
    -> +[KSImageNamed sharedPlugin]
    <- +[KSImageNamed sharedPlugin]
    -> -[KSImageNamed completionStringsForType:]
    <- -[KSImageNamed completionStringsForType:]
<- -[DVTSourceTextView(KSImageNamedSwizzle) swizzle_shouldAutoCompleteAtLocation:]
-> -[DVTSourceTextView(KSImageNamedSwizzle) swizzle_shouldAutoCompleteAtLocation:]
    -> +[KSImageNamed sharedPlugin]
    <- +[KSImageNamed sharedPlugin]
    -> -[KSImageNamed completionStringsForType:]
    <- -[KSImageNamed completionStringsForType:]
<- -[DVTSourceTextView(KSImageNamedSwizzle) swizzle_shouldAutoCompleteAtLocation:]
```

I've only tested this on Xcode 5.0.1.
